### PR TITLE
Add manifest to output jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'java'
     id 'application'
+    id 'idea'
 }
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -17,3 +17,11 @@ dependencies {
 application {
     mainClassName = 'com.ToyRobot.App'
 }
+
+jar {
+    manifest {
+        attributes(
+                'Main-Class': 'com.ToyRobot.App'
+        )
+    }
+}


### PR DESCRIPTION
Previously, the output jar wouldn't run because it didn't have the App's entrypoint.